### PR TITLE
FIX: Aladin compatible in explorer. Branch ztf_explorer/feature/keybo…

### DIFF
--- a/components/misc/Aladin.vue
+++ b/components/misc/Aladin.vue
@@ -96,7 +96,7 @@ export default class Aladin extends Vue {
     canvasCtx.fillText(source.data.class, source.x + 2 + xShift, source.y + 10)
   }
 
-  @Watch('objects')
+  // @Watch('objects')
   addObjects(aladin, objects) {
     aladin.removeLayers()
     const sources = []


### PR DESCRIPTION
When in ZTF Explorer uses aladin component, the component doesn't works correctly.  Comment line 99. When @Watch looks changes in 'objects', this trigger an error. 
Solution: comment @Watch 

