### PR TITLE
fix outside when use bars of sigma_corr_ext

### DIFF
--- a/components/plots/LightCurvePlot.vue
+++ b/components/plots/LightCurvePlot.vue
@@ -51,8 +51,6 @@ export default class LightCurvePlot extends Vue {
         nonDetections,
         this.fontColor
       )
-      differenceLightCurveOptions.getSeries()
-      differenceLightCurveOptions.getLegend()
       this.chartOptions = differenceLightCurveOptions
     }
     if (type === 'apparent') {
@@ -61,8 +59,6 @@ export default class LightCurvePlot extends Vue {
         nonDetections,
         this.fontColor
       )
-      apparentLightCurveOptions.getSeries()
-      apparentLightCurveOptions.getLegend()
       this.chartOptions = apparentLightCurveOptions
     }
     if (type === 'folded') {
@@ -72,8 +68,6 @@ export default class LightCurvePlot extends Vue {
         this.fontColor,
         period
       )
-      foldedLightCurveOptions.getSeries()
-      foldedLightCurveOptions.getLegend()
       this.chartOptions = foldedLightCurveOptions
     }
   }

--- a/components/plots/plot-types/apparent.js
+++ b/components/plots/plot-types/apparent.js
@@ -1,6 +1,13 @@
 import { LightCurveOptions } from './utils/light-curve-utils'
 
 export class ApparentLightCurveOptions extends LightCurveOptions {
+  constructor(detections, nonDetections, fontColor) {
+    super(detections, nonDetections, fontColor)
+    this.getSeries()
+    this.getLegend()
+    this.getBoundaries()
+  }
+
   getSeries() {
     const bands = new Set(this.detections.map((item) => item.fid))
     this.addDetections(this.detections, bands)
@@ -76,5 +83,15 @@ export class ApparentLightCurveOptions extends LightCurveOptions {
     const bands = Array.from(new Set(this.detections.map((item) => item.fid)))
     const legend = bands.map((band) => this.bandMap[band].name)
     this.options.legend.data = legend
+  }
+
+  getBoundaries() {
+    const detections = this.detections.filter(
+      (x) => x.magpsf_corr < 100 && x.sigmapsf_corr_ext < 2
+    )
+    const minValues = detections.map((x) => x.magpsf_corr - x.sigmapsf_corr_ext)
+    const maxValues = detections.map((x) => x.magpsf_corr + x.sigmapsf_corr_ext)
+    this.options.yAxis.min = parseInt(Math.min.apply(Math, minValues)) - 1
+    this.options.yAxis.max = parseInt(Math.max.apply(Math, maxValues)) + 1
   }
 }

--- a/components/plots/plot-types/apparent.js
+++ b/components/plots/plot-types/apparent.js
@@ -3,9 +3,9 @@ import { LightCurveOptions } from './utils/light-curve-utils'
 export class ApparentLightCurveOptions extends LightCurveOptions {
   constructor(detections, nonDetections, fontColor) {
     super(detections, nonDetections, fontColor)
+    this.detections = this.detections.filter((x) => x.magpsf_corr <= 23)
     this.getSeries()
     this.getLegend()
-    this.getBoundaries()
   }
 
   getSeries() {
@@ -49,7 +49,7 @@ export class ApparentLightCurveOptions extends LightCurveOptions {
   formatError(detections, band) {
     return detections
       .filter(function (x) {
-        return x.fid === band && x.corrected && x.magpsf_corr < 100
+        return x.fid === band && x.corrected
       })
       .map(function (x) {
         if (x.sigmapsf_corr_ext > 2) {
@@ -66,7 +66,7 @@ export class ApparentLightCurveOptions extends LightCurveOptions {
   formatDetections(detections, band) {
     return detections
       .filter(function (x) {
-        return x.fid === band && x.corrected && x.magpsf_corr < 100
+        return x.fid === band && x.corrected
       })
       .map(function (x) {
         return [
@@ -83,15 +83,5 @@ export class ApparentLightCurveOptions extends LightCurveOptions {
     const bands = Array.from(new Set(this.detections.map((item) => item.fid)))
     const legend = bands.map((band) => this.bandMap[band].name)
     this.options.legend.data = legend
-  }
-
-  getBoundaries() {
-    const detections = this.detections.filter(
-      (x) => x.magpsf_corr < 100 && x.sigmapsf_corr_ext < 2
-    )
-    const minValues = detections.map((x) => x.magpsf_corr - x.sigmapsf_corr_ext)
-    const maxValues = detections.map((x) => x.magpsf_corr + x.sigmapsf_corr_ext)
-    this.options.yAxis.min = parseInt(Math.min.apply(Math, minValues)) - 1
-    this.options.yAxis.max = parseInt(Math.max.apply(Math, maxValues)) + 1
   }
 }

--- a/components/plots/plot-types/difference.js
+++ b/components/plots/plot-types/difference.js
@@ -3,9 +3,9 @@ import { LightCurveOptions } from './utils/light-curve-utils'
 export class DifferenceLightCurveOptions extends LightCurveOptions {
   constructor(detections, nonDetections, fontColor) {
     super(detections, nonDetections, fontColor)
+    this.detections = this.detections.filter((x) => x.magpsf <= 23)
     this.getSeries()
     this.getLegend()
-    this.getBoundaries()
   }
 
   getSeries() {
@@ -103,19 +103,5 @@ export class DifferenceLightCurveOptions extends LightCurveOptions {
       bands.map((band) => this.bandMap[band].name + ' non-detections')
     )
     this.options.legend.data = legend
-  }
-
-  getBoundaries() {
-    const diffmaglim = this.nonDetections
-      .filter((x) => x.diffmaglim > 10)
-      .map((x) => x.diffmaglim)
-    const minValues = this.detections
-      .map((x) => x.magpsf - x.sigmapsf)
-      .concat(diffmaglim)
-    const maxValues = this.detections
-      .map((x) => x.magpsf + x.sigmapsf)
-      .concat(diffmaglim)
-    this.options.yAxis.min = parseInt(Math.min.apply(Math, minValues)) - 1
-    this.options.yAxis.max = parseInt(Math.max.apply(Math, maxValues)) + 1
   }
 }

--- a/components/plots/plot-types/difference.js
+++ b/components/plots/plot-types/difference.js
@@ -1,6 +1,13 @@
 import { LightCurveOptions } from './utils/light-curve-utils'
 
 export class DifferenceLightCurveOptions extends LightCurveOptions {
+  constructor(detections, nonDetections, fontColor) {
+    super(detections, nonDetections, fontColor)
+    this.getSeries()
+    this.getLegend()
+    this.getBoundaries()
+  }
+
   getSeries() {
     const bands = new Set(this.detections.map((item) => item.fid))
     this.addDetections(this.detections, bands)
@@ -96,5 +103,19 @@ export class DifferenceLightCurveOptions extends LightCurveOptions {
       bands.map((band) => this.bandMap[band].name + ' non-detections')
     )
     this.options.legend.data = legend
+  }
+
+  getBoundaries() {
+    const diffmaglim = this.nonDetections
+      .filter((x) => x.diffmaglim > 10)
+      .map((x) => x.diffmaglim)
+    const minValues = this.detections
+      .map((x) => x.magpsf - x.sigmapsf)
+      .concat(diffmaglim)
+    const maxValues = this.detections
+      .map((x) => x.magpsf + x.sigmapsf)
+      .concat(diffmaglim)
+    this.options.yAxis.min = parseInt(Math.min.apply(Math, minValues)) - 1
+    this.options.yAxis.max = parseInt(Math.max.apply(Math, maxValues)) + 1
   }
 }

--- a/components/plots/plot-types/folded.js
+++ b/components/plots/plot-types/folded.js
@@ -3,10 +3,10 @@ import { LightCurveOptions } from './utils/light-curve-utils'
 export class FoldedLightCurveOptions extends LightCurveOptions {
   constructor(detections, nonDetections, fontColor, period) {
     super(detections, nonDetections, fontColor)
+    this.detections = this.detections.filter((x) => x.magpsf_corr <= 23)
     this.period = period
     this.getSeries()
     this.getLegend()
-    this.getBoundaries()
   }
 
   getSeries(data) {
@@ -49,14 +49,7 @@ export class FoldedLightCurveOptions extends LightCurveOptions {
 
   formatDetections(detections, band, period) {
     const folded1 = detections
-      .filter(function (x) {
-        return (
-          x.fid === band &&
-          x.corrected &&
-          x.magpsf_corr != null &&
-          x.magpsf_corr < 100
-        )
-      })
+      .filter((x) => x.fid === band && x.corrected)
       .map((x) => {
         const phase = (x.mjd % period) / period
         return [
@@ -84,7 +77,7 @@ export class FoldedLightCurveOptions extends LightCurveOptions {
         )
       })
       .map(function (x) {
-        if (x.sigmapsf_corr > 1) {
+        if (x.sigmapsf_corr > 2) {
           return [null, null, null]
         }
         const phase = (x.mjd % period) / period
@@ -112,15 +105,5 @@ export class FoldedLightCurveOptions extends LightCurveOptions {
     )
     this.options.legend.data = legend
     this.options.title.subtext = 'Period: ' + this.period.toFixed(3) + ' days'
-  }
-
-  getBoundaries() {
-    const detections = this.detections.filter(
-      (x) => x.magpsf_corr < 100 && x.sigmapsf_corr_ext < 2
-    )
-    const minValues = detections.map((x) => x.magpsf_corr - x.sigmapsf_corr_ext)
-    const maxValues = detections.map((x) => x.magpsf_corr + x.sigmapsf_corr_ext)
-    this.options.yAxis.min = parseInt(Math.min.apply(Math, minValues)) - 1
-    this.options.yAxis.max = parseInt(Math.max.apply(Math, maxValues)) + 1
   }
 }

--- a/components/plots/plot-types/folded.js
+++ b/components/plots/plot-types/folded.js
@@ -4,6 +4,9 @@ export class FoldedLightCurveOptions extends LightCurveOptions {
   constructor(detections, nonDetections, fontColor, period) {
     super(detections, nonDetections, fontColor)
     this.period = period
+    this.getSeries()
+    this.getLegend()
+    this.getBoundaries()
   }
 
   getSeries(data) {
@@ -56,7 +59,13 @@ export class FoldedLightCurveOptions extends LightCurveOptions {
       })
       .map((x) => {
         const phase = (x.mjd % period) / period
-        return [phase, x.magpsf_corr, x.candid, x.sigmapsf_corr, x.isdiffpos]
+        return [
+          phase,
+          x.magpsf_corr,
+          x.candid,
+          x.sigmapsf_corr_ext,
+          x.isdiffpos,
+        ]
       })
     const folded2 = folded1.map((x) => {
       return [x[0] + 1, x[1], x[2], x[3], x[4]]
@@ -81,8 +90,8 @@ export class FoldedLightCurveOptions extends LightCurveOptions {
         const phase = (x.mjd % period) / period
         return [
           phase,
-          x.magpsf_corr - x.sigmapsf_corr,
-          x.magpsf_corr + x.sigmapsf_corr,
+          x.magpsf_corr - x.sigmapsf_corr_ext,
+          x.magpsf_corr + x.sigmapsf_corr_ext,
         ]
       })
 
@@ -103,5 +112,15 @@ export class FoldedLightCurveOptions extends LightCurveOptions {
     )
     this.options.legend.data = legend
     this.options.title.subtext = 'Period: ' + this.period.toFixed(3) + ' days'
+  }
+
+  getBoundaries() {
+    const detections = this.detections.filter(
+      (x) => x.magpsf_corr < 100 && x.sigmapsf_corr_ext < 2
+    )
+    const minValues = detections.map((x) => x.magpsf_corr - x.sigmapsf_corr_ext)
+    const maxValues = detections.map((x) => x.magpsf_corr + x.sigmapsf_corr_ext)
+    this.options.yAxis.min = parseInt(Math.min.apply(Math, minValues)) - 1
+    this.options.yAxis.max = parseInt(Math.max.apply(Math, maxValues)) + 1
   }
 }

--- a/components/plots/plot-types/utils/light-curve-utils.js
+++ b/components/plots/plot-types/utils/light-curve-utils.js
@@ -8,7 +8,7 @@ export class LightCurveOptions {
       // 3: { name: 'i', color: '#2E2EFE' },
     }
     this.detections = detections.filter((x) => x.fid === 1 || x.fid === 2)
-    this.nonDetections = nonDetections
+    this.nonDetections = nonDetections.filter((x) => x.diffmaglim <= 23)
     this.fontColor = fontColor
     this.options = {
       grid: {
@@ -98,6 +98,8 @@ export class LightCurveOptions {
           show: false,
         },
         inverse: true,
+        min: (x) => parseInt(x.min - 3),
+        max: (x) => parseInt(x.max + 3),
       },
       textStyle: {
         color: this.fontColor,
@@ -119,13 +121,6 @@ export class LightCurveOptions {
    */
   getSeries() {
     throw new Error("Method 'getSeries()' must be implemented")
-  }
-
-  /**
-   * Sets options series from data
-   */
-  getBoundaries() {
-    throw new Error("Method 'getBoundaries()' must be implemented")
   }
 
   formatTooltip(params) {

--- a/components/plots/plot-types/utils/light-curve-utils.js
+++ b/components/plots/plot-types/utils/light-curve-utils.js
@@ -105,7 +105,6 @@ export class LightCurveOptions {
       },
       series: [],
     }
-    this.getBoundaries(detections, nonDetections)
   }
 
   /**
@@ -120,6 +119,13 @@ export class LightCurveOptions {
    */
   getSeries() {
     throw new Error("Method 'getSeries()' must be implemented")
+  }
+
+  /**
+   * Sets options series from data
+   */
+  getBoundaries() {
+    throw new Error("Method 'getBoundaries()' must be implemented")
   }
 
   formatTooltip(params) {
@@ -239,19 +245,5 @@ export class LightCurveOptions {
     } else {
       return 'rgb(' + r + ', ' + g + ', ' + b + ')'
     }
-  }
-
-  getBoundaries(detections, nonDetections) {
-    let minValues = detections.map((x) => x.magpsf - x.sigmapsf)
-    let maxValues = detections.map((x) => x.magpsf + x.sigmapsf)
-    if (nonDetections.length > 0) {
-      const diffmaglim = nonDetections
-        .filter((x) => x.diffmaglim > 10)
-        .map((x) => x.diffmaglim)
-      minValues = minValues.concat(diffmaglim)
-      maxValues = maxValues.concat(diffmaglim)
-    }
-    this.options.yAxis.min = parseInt(Math.min.apply(Math, minValues)) - 1
-    this.options.yAxis.max = parseInt(Math.max.apply(Math, maxValues)) + 1
   }
 }


### PR DESCRIPTION
- Fix boundaries when plot apparent light curve
- Implement method `getBoundary` in each class of plot

For [object](http://dev.alerce.online/object/ZTF18abaehqw)

Before:
![image](https://user-images.githubusercontent.com/19624900/90070365-c29ba300-dcc1-11ea-86b5-a006ba55c143.png)

After:
![image](https://user-images.githubusercontent.com/19624900/90070352-badbfe80-dcc1-11ea-9df8-4fee87c3075b.png)
