### PR TITLE
Feature/search list oids

### DIFF
--- a/components/buttons/DownloadLightcurveButton.vue
+++ b/components/buttons/DownloadLightcurveButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-btn @click="downloadLightcurve" outlined small>
+  <v-btn outlined small @click="downloadLightcurve">
     <v-icon left small>cloud_download</v-icon>Download
   </v-btn>
 </template>

--- a/components/inputs/DefaultSearch.vue
+++ b/components/inputs/DefaultSearch.vue
@@ -2,7 +2,17 @@
   <v-layout wrap align-center>
     <!--Object ID-->
     <v-flex xs12 sm12 md12>
-      <v-text-field v-model="localValue.oid" label="Object ID" />
+      <v-combobox
+        v-model="localValue.oid"
+        label="Object ID"
+        append-icon=" "
+        :delimiters="delimiters"
+        disable-lookup
+        clearable
+        deletable-chips
+        multiple
+        small-chips
+      />
     </v-flex>
     <!--Classifier-->
     <v-flex xs12 sm12 md6 lg6>
@@ -54,6 +64,8 @@ export default class DefaultSearch extends Vue {
   @Prop({ type: Array, default: () => [1, 2000] }) limitNdet
 
   localValue = {}
+  _localOids = []
+  delimiters = [' ', ',', ';']
 
   get probLabel() {
     return this.value.probability

--- a/components/inputs/DefaultSearch.vue
+++ b/components/inputs/DefaultSearch.vue
@@ -67,11 +67,12 @@ export default class DefaultSearch extends Vue {
   delimiters = [' ', ',', ';']
 
   get localOids() {
-    return this.oids
+    return this.localValue.oid
   }
 
   set localOids(val) {
     this.oids = this.formatOids(val)
+    this.localValue.oid = this.oids
   }
 
   get probLabel() {
@@ -86,7 +87,6 @@ export default class DefaultSearch extends Vue {
     let oids = listOfOids.reduce(reducer, [])
     oids = oids.map((x) => x.trim())
     oids = Array.from(new Set(oids))
-    this.localValue.oid = oids
     return oids
   }
 

--- a/components/inputs/DefaultSearch.vue
+++ b/components/inputs/DefaultSearch.vue
@@ -1,13 +1,12 @@
 <template>
   <v-layout wrap align-center>
-    <!--Object ID-->
+    <!--Objects ID-->
     <v-flex xs12 sm12 md12>
       <v-combobox
-        v-model="localValue.oid"
+        v-model="localOids"
         label="Object ID"
         append-icon=" "
         :delimiters="delimiters"
-        disable-lookup
         clearable
         deletable-chips
         multiple
@@ -64,13 +63,31 @@ export default class DefaultSearch extends Vue {
   @Prop({ type: Array, default: () => [1, 2000] }) limitNdet
 
   localValue = {}
-  _localOids = []
+  oids = []
   delimiters = [' ', ',', ';']
+
+  get localOids() {
+    return this.oids
+  }
+
+  set localOids(val) {
+    this.oids = this.formatOids(val)
+  }
 
   get probLabel() {
     return this.value.probability
       ? 'Probability ≥' + this.value.probability
       : 'Probability ≥ 0.00'
+  }
+
+  formatOids(listOfOids) {
+    const reducer = (accumulator, current) =>
+      accumulator.concat(current.split(/[,;]|\s|\n/g))
+    let oids = listOfOids.reduce(reducer, [])
+    oids = oids.map((x) => x.trim())
+    oids = Array.from(new Set(oids))
+    this.localValue.oid = oids
+    return oids
   }
 
   @Watch('value', { immediate: true, deep: true })

--- a/components/inputs/DefaultSearch.vue
+++ b/components/inputs/DefaultSearch.vue
@@ -82,7 +82,7 @@ export default class DefaultSearch extends Vue {
 
   formatOids(listOfOids) {
     const reducer = (accumulator, current) =>
-      accumulator.concat(current.split(/[,;]|\s|\n/g))
+      accumulator.concat(current.split(/[,;]*\s|\s|\n/g))
     let oids = listOfOids.reduce(reducer, [])
     oids = oids.map((x) => x.trim())
     oids = Array.from(new Set(oids))


### PR DESCRIPTION
Closes [#178](https://github.com/alercebroker/ztf_explorer/issues/178)

Features:
- Reception of a list of objects separated for semicolon, comma, white spaces and newline
- Delete some objects in the list
- Clear all object ids
- When you copy a list from a file and paste in the field this works

![image](https://user-images.githubusercontent.com/19624900/90690243-5a0f7180-e23f-11ea-98ab-5ca55637707d.png)
