### PR TITLE
round to ceil in calculate total of pages

### DIFF
--- a/components/tables/ResultTable.vue
+++ b/components/tables/ResultTable.vue
@@ -77,7 +77,7 @@ export default class ResultTable extends Vue {
   }
 
   get numPages() {
-    return Math.round(this.total / this.localPaginationOptions.itemsPerPage)
+    return Math.ceil(this.total / this.localPaginationOptions.itemsPerPage)
   }
 
   get header() {


### PR DESCRIPTION
problem when I have 21 objects like response:

before:
- 21 total objects
- 20 per page
- calculation of pages: Math.round(21/21) = Math.round(1.05)) = 1

now:
- calculation of pages: Math.ceil(1.05) = 2